### PR TITLE
Use Maildir as default format; generalize labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,11 @@ To use it, follow these steps:
 1. Export your Google Hangouts data using [Google Takeout](https://www.google.com/settings/takeout).  You'll be using the "Hangouts.json" file from the archive this gives you.
 2. [Enable IMAP](https://support.google.com/mail/troubleshooter/1668960?hl=en#ts=1665018) on your GMail account.
 3. Check the box to make Chats show up in IMAP, as detailed [here](http://readwrite.com/2011/09/16/google_liberates_gmail_chat_logs_via_imap)
-4. Download your GMail IMAP chats folder ([Gmail]/Chats) using a desktop email client.  I used Thunderbird.  You'll be using the mbox-format mail-folder file (I recommend Thunderbird's [ImportExportTools](https://addons.mozilla.org/en-us/thunderbird/addon/importexporttools/) addon to assist in obtaining the file required).
+4. Download your GMail IMAP chats folder ([Gmail]/Chats) using a desktop email client (script tested with Thunderbird).  This script supports Maildir mailboxes by default, but the mbox format can also be used via the `-m` flag.  I recommend Thunderbird's [ImportExportTools](https://addons.mozilla.org/en-us/thunderbird/addon/importexporttools/) addon to assist in obtaining the file required.  If using Thunderbird and Maildir, it's suggested to backup your emails first & enable maildir at the local level if you regularly use Thunderbird.  Maildir can be enabled in the settings 3 different ways:
+ - Options - Advanced - Advanced Configuration - Message Store Type for new accounts
+ - Account Settings - Server Settings - Message Storage - Message Store Type
+ - Account Settings - Local Folders - Message Storage - Message Store Type
 5. Check out this repository to a directory.
-6. Run this command: `python gtalk_export.py -m <path_to_mbox_file> -j <path_to_json_file> -n <your name> -e <your email>`
+6. Run this command: `python gtalk_export.py -p <path/to/mbox_file_or_maildir_directory> -j <path/to/json_file> -n <your name> -e <your email> ` **If using mbox, add `-m` to the end of the command**
  
 The program needs your name and email so that it knows who "you" are, and by extension who the other party is -- some of the mbox-format chats just list participants with no indication of which one is the account being parsed.  Running the command will generate a large number of .txt files in the current working directory (one for each contact you conversed with).


### PR DESCRIPTION
I decided to stop fighting against the burdensome mbox format and add support for Maildir, which Thunderbird now supports. Way easier than trying to diagnose whether mbox issues I had came from Thunderbird's output, the ImportExportTools addon, the parser, or this code. 

I changed a little bit in the arguments to account for Maildir support. 

mbox uses a file, while Maildir uses directories...replacing "location" with "path" seemed like a natural way to allow for an intuitive -p argument instead of -m, which would now be used for forcing mbox. Where functions/vars had "mbox" in their names, they now have "mailbox." 

Things to discuss:
- [x] Setting Maildir as the default
- [x] Style: function/variable name changes 
- [x] Style: how to handle arguments
- [ ] Update README

Things to do that I refuse to do:
- [ ] Test against some mbox files
