### PR TITLE
Various fixes to handle Thunderbird mbox files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,11 +15,14 @@ To use it, follow these steps:
 1. Export your Google Hangouts data using [Google Takeout](https://www.google.com/settings/takeout).  You'll be using the "Hangouts.json" file from the archive this gives you.
 2. [Enable IMAP](https://support.google.com/mail/troubleshooter/1668960?hl=en#ts=1665018) on your GMail account.
 3. Check the box to make Chats show up in IMAP, as detailed [here](http://readwrite.com/2011/09/16/google_liberates_gmail_chat_logs_via_imap)
-4. Download your GMail IMAP chats folder ([Gmail]/Chats) using a desktop email client (script tested with Thunderbird).  This script supports Maildir mailboxes by default, but the mbox format can also be used via the `-m` flag.  I recommend Thunderbird's [ImportExportTools](https://addons.mozilla.org/en-us/thunderbird/addon/importexporttools/) addon to assist in obtaining the file required.  If using Thunderbird and Maildir, it's suggested to backup your emails first & enable maildir at the local level if you regularly use Thunderbird.  Maildir can be enabled in the settings 3 different ways:
- - Options - Advanced - Advanced Configuration - Message Store Type for new accounts
- - Account Settings - Server Settings - Message Storage - Message Store Type
- - Account Settings - Local Folders - Message Storage - Message Store Type
-5. Check out this repository to a directory.
-6. Run this command: `python gtalk_export.py -p <path/to/mbox_file_or_maildir_directory> -j <path/to/json_file> -n <your name> -e <your email> ` **If using mbox, add `-m` to the end of the command**
+4. Download your GMail IMAP chats folder ([Gmail]/Chats) using a desktop email client (script tested with Thunderbird).
+5. Get the files that contain your chats. This script supports both the mbox format (one file, many "emails") and the Maildir format (one file per "email"):
+  - If using mbox, you can simply copy the mbox file directly from your profile directory (it may be located at `[thunderbird_profile]/ImapMail/imap.gmail.com/[Gmail].sbd/Chats`). Or you can use Thunderbird's [ImportExportTools](https://addons.mozilla.org/en-us/thunderbird/addon/importexporttools/) addon to assist in obtaining the file required.
+  - To use Maildir, you must enable the Maildir backend for Thunderbird. It's suggested to backup your emails first & enable maildir at the local level if you regularly use Thunderbird. Maildir can be enabled in the settings 3 different ways:
+    - Options - Advanced - Advanced Configuration - Message Store Type for new accounts
+    - Account Settings - Server Settings - Message Storage - Message Store Type
+    - Account Settings - Local Folders - Message Storage - Message Store Type
+6. Check out this repository to a directory.
+7. Run this command: `python gtalk_export.py -p <path/to/mbox_file_or_maildir_directory> -j <path/to/json_file> -n <your name> -e <your email> ` **If using mbox, add `-m` to the end of the command**
  
 The program needs your name and email so that it knows who "you" are, and by extension who the other party is -- some of the mbox-format chats just list participants with no indication of which one is the account being parsed.  Running the command will generate a large number of .txt files in the current working directory (one for each contact you conversed with).

--- a/gtalk_export.py
+++ b/gtalk_export.py
@@ -40,7 +40,7 @@ def write_to_file(filename, lines):
     
     '''
     with open(filename, "a") as myfile:
-            myfile.write(u"".join(lines).encode('utf-8'))
+            myfile.write("".join(lines))
 
 def parse_mailbox(mailbox_path, my_name, my_email, timestamp_format, use_mbox):
     if not use_mbox:
@@ -100,7 +100,7 @@ def parse_mailbox(mailbox_path, my_name, my_email, timestamp_format, use_mbox):
             
             pars = HTMLParser.HTMLParser()
             outline = "%s <%s> %s\n" % (timestamp, from_name, pars.unescape(payload))
-            messageobj.append(outline)
+            messageobj.append(outline.encode('utf-8'))
         else:
             #We're in an old Google Talk Jabber conversation message
 
@@ -129,7 +129,7 @@ def parse_mailbox(mailbox_path, my_name, my_email, timestamp_format, use_mbox):
                     # like a time-gap or user-unavailable message
                     continue
                 outline = "%s <%s> %s\n" % (timestamp, speaker, content)
-                messageobj.append(outline)
+                messageobj.append(outline.encode('utf-8'))
 
         write_to_file("%s.txt" % filename_sanitize(name)[:250], messageobj)
 


### PR DESCRIPTION
mbox support seemed to be broken. In addition, I fixed a few unicode/encoding issues I ran into:

* Skip messages that lack metadata
* Properly (I hope) handle Unicode
* Remove duplicate messages
* More principled handling of quoted-printable encoding

I haven't tested these changes with maildir format. I tried not to do anything that would it break it, but I can't guarantee anything.